### PR TITLE
Allow projects to opt in to running Minitest cops

### DIFF
--- a/rubocop-37signals.gemspec
+++ b/rubocop-37signals.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rubocop"
   s.add_dependency "rubocop-rails"
   s.add_dependency "rubocop-performance"
+  s.add_dependency "rubocop-minitest"
 
   s.files = %w[ rubocop.yml ]
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-minitest
 
 inherit_mode:
   merge:


### PR DESCRIPTION
### Summary
Add `rubocop-minitest`.

### Why
As a former `RSpec` user it would be nice to be able to opt-in to some community syntax guidance when it comes to `Minitest`.

### How
Since the `.rubocop.yml` is configured with the `AllCops.DisabledByDefault` set to `true` this commit doesn’t enforce any new cops. Instead projects (or individual programmers) can opt in to having their editor lint `Minitest` without having to manipulate the project’s `Gemfile`.