### PR TITLE
Add shared eslint config for all 37s projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,42 @@ inherit_gem: { rubocop-37signals: rubocop.yml }
 
 App-specific config may follow, overriding the house style.
 
+## JavaScript
+
+We use [ESLint](https://eslint.org) for our JavaScript. You'll need eslint 9 or higher to use our shared config.
+
+The configurations is based on @eslint/js's [recommended](https://github.com/eslint/eslint/blob/main/packages/js/src/configs/eslint-recommended.js) config,
+with a few more stylistic rules added to reflect our preferences.
+
+To use our ruleset as a baseline, add the `@37signals/eslint-config` package:
+
+```bash
+npm install --save-dev @37signals/eslint-config
+```
+
+Or with Yarn:
+
+```bash
+yarn add --dev @37signals/eslint-config
+```
+
+And extend it in your eslint.config.mjs file:
+
+```js
+import houseStyle from "@37signals/eslint-config"
+
+export default [
+  houseStyle,
+  {
+    rules: {
+      "no-unused-vars": [ "off" ]
+      ...
+    }
+  }
+]
+
+```
+
 ## SCSS
 
 We use [Stylelint](https://stylelint.io) for our SCSS.

--- a/eslint-config/.gitignore
+++ b/eslint-config/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/package-lock.json
+yarn.lock

--- a/eslint-config/eslint.config.mjs
+++ b/eslint-config/eslint.config.mjs
@@ -1,0 +1,42 @@
+import js from "@eslint/js"
+import globals from "globals"
+import stylistic from "@stylistic/eslint-plugin-js"
+
+export default {
+  languageOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    globals: {
+      "global": "readonly",
+      ...globals.browser
+    }
+  },
+  plugins: {
+    "@stylistic/js": stylistic
+  },
+  ignores: [
+    "dist/*",
+    "vendor/*"
+  ],
+  rules: Object.assign({}, js.configs.recommended.rules, {
+    "@stylistic/js/array-bracket-spacing": [ "error", "always" ],
+    "@stylistic/js/arrow-spacing": [ "error", { "before": true, "after": true } ],
+    "@stylistic/js/block-spacing": [ "error", "always" ],
+    "@stylistic/js/comma-dangle": [ "error", "never" ],
+    "@stylistic/js/comma-spacing": [ "error", { "before": false, "after": true } ],
+    "@stylistic/js/comma-style": [ "error", "last" ],
+    "@stylistic/js/computed-property-spacing": [ "error", "never" ],
+    "@stylistic/js/eol-last": "error",
+    "@stylistic/js/function-call-spacing": [ "error", "never" ],
+    "@stylistic/js/indent": [ "error", 2, { "SwitchCase": 1 } ],
+    "@stylistic/js/no-trailing-spaces": "error",
+    "@stylistic/js/quotes": [ "error", "double", { "avoidEscape": true } ],
+    "@stylistic/js/semi": [ "error", "never" ],
+    "@stylistic/js/space-infix-ops": [ "error" ],
+    "@stylistic/js/keyword-spacing": [ "error" ],
+    "curly": [ "error", "multi-line" ],
+    "no-unused-vars": [ "error", { "varsIgnorePattern": "_" } ],
+    "no-var": "error",
+    "prefer-const": [ "error", { "destructuring": "all" } ]
+  })
+}

--- a/eslint-config/eslint.config.mjs
+++ b/eslint-config/eslint.config.mjs
@@ -35,7 +35,7 @@ export default {
     "@stylistic/js/space-infix-ops": [ "error" ],
     "@stylistic/js/keyword-spacing": [ "error" ],
     "curly": [ "error", "multi-line" ],
-    "no-unused-vars": [ "error", { "varsIgnorePattern": "_" } ],
+    "no-unused-vars": [ "error", { "argsIgnorePattern": "^_", "caughtErrors": "none" } ],
     "no-var": "error",
     "prefer-const": [ "error", { "destructuring": "all" } ]
   })

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@37signals/eslint-config",
+  "version": "0.0.1",
+  "description": "Shared eslint config",
+  "main": "eslint.config.mjs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/basecamp/house-style.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/basecamp/house-style/issues"
+  },
+  "homepage": "https://github.com/basecamp/house-style#readme",
+  "dependencies": {
+    "@eslint/js": "^9.1.1",
+    "@stylistic/eslint-plugin-js": "^1.7.2",
+    "eslint": "^9.1.1",
+    "globals": "^15.0.0"
+  }
+}


### PR DESCRIPTION
Extracted [from the House editor](https://github.com/basecamp/house/blob/7f3c99b4c8dc57eebfe0f6ae2caf4139e9495260/eslint.config.mjs). This is the kind of config that takes some time to get right in a new project, so sharing it should be useful.

The config is based on the eslint recommended rules with some additional rules from the stylistic plugin. This seems to cover most of our stylistic preferences, but we can always add more rules as needed or change the existing ones.

It uses the new [eslint 9 flat config format](https://eslint.org/blog/2022/08/new-config-system-part-2/), which is the way to go for future projects.

You can see the new rules applied to BC4 in https://github.com/basecamp/bc3/pull/7477