### PR TITLE
Split Ruby / Rails rubocop rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ gem "rubocop-37signals", github: "basecamp/house-style", require: false
 And create a boilerplate `.rubocop.yml` that inherits from `rubocop-37signals`:
 ```yaml
 # 37signals house style
-inherit_gem: { rubocop-37signals: rubocop.yml }
+inherit_gem: { rubocop-37signals: rubocop-rails.yml }
 ```
 
 App-specific config may follow, overriding the house style.

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -1,0 +1,41 @@
+inherit_from: rubocop-ruby.yml
+
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-minitest
+
+inherit_mode:
+  merge:
+    - Exclude
+
+AllCops:
+  Exclude:
+    - "data/**/*"
+    - "db/*schema.rb"
+    - "log/**/*"
+    - "node_modules/**/*"
+    - "public/**/*"
+    - "storage/**/*"
+    - "tmp/**/*"
+    - "vendor/**/*"
+
+Performance:
+  Exclude:
+    - "test/**/*"
+
+# Prefer assert_not over assert !
+Rails/AssertNot:
+  Include:
+    - "test/**/*"
+
+# Prefer assert_not_x over refute_x
+Rails/RefuteMethods:
+  Include:
+    - "test/**/*"
+
+Performance/FlatMap:
+  Enabled: true
+
+Performance/UnfreezeString:
+  Enabled: true

--- a/rubocop-ruby.yml
+++ b/rubocop-ruby.yml
@@ -1,37 +1,9 @@
-require:
-  - rubocop-performance
-  - rubocop-rails
-  - rubocop-minitest
-
 inherit_mode:
   merge:
     - Exclude
 
 AllCops:
   DisabledByDefault: true
-  Exclude:
-    - "data/**/*"
-    - "db/*schema.rb"
-    - "log/**/*"
-    - "node_modules/**/*"
-    - "public/**/*"
-    - "storage/**/*"
-    - "tmp/**/*"
-    - "vendor/**/*"
-
-Performance:
-  Exclude:
-    - "test/**/*"
-
-# Prefer assert_not over assert !
-Rails/AssertNot:
-  Include:
-    - "test/**/*"
-
-# Prefer assert_not_x over refute_x
-Rails/RefuteMethods:
-  Include:
-    - "test/**/*"
 
 # We generally prefer &&/|| but like low-precedence and/or in context
 Style/AndOr:
@@ -238,10 +210,3 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   Enabled: true
-
-Performance/FlatMap:
-  Enabled: true
-
-Performance/UnfreezeString:
-  Enabled: true
-


### PR DESCRIPTION
This enables us to adopt the House Style rubocop rules within the Chef cookbooks we use in Ops, adopting a consistent style across the board, without adding dependencies on other gems such as rubocop-rails or rubocop-performance.