### PR TITLE
Move Rails-specific Style Include directories to Rails config

### DIFF
--- a/rubocop-ruby.yml
+++ b/rubocop-ruby.yml
@@ -147,12 +147,6 @@ Layout/SpaceInsideReferenceBrackets:
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
-  Include:
-    - "app/**/*"
-    - "config/**/*"
-    - "lib/**/*"
-    - "test/**/*"
-    - "Gemfile"
 
 # Detect hard tabs, no hard tabs.
 Layout/IndentationStyle:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -24,6 +24,12 @@ Performance:
   Exclude:
     - "test/**/*"
 
+Performance/FlatMap:
+  Enabled: true
+
+Performance/UnfreezeString:
+  Enabled: true
+
 # Prefer assert_not over assert !
 Rails/AssertNot:
   Include:
@@ -34,8 +40,11 @@ Rails/RefuteMethods:
   Include:
     - "test/**/*"
 
-Performance/FlatMap:
-  Enabled: true
-
-Performance/UnfreezeString:
-  Enabled: true
+# Use `"foo"` not `'foo'` unless escaping is required
+Style/StringLiterals:
+  Include:
+    - "app/**/*"
+    - "config/**/*"
+    - "lib/**/*"
+    - "test/**/*"
+    - "Gemfile"


### PR DESCRIPTION
Ensures that Rails-specific directory include config doesn't hinder style checks in non-Rails repos, e.g. Chef cookbooks.

cc @jeremy 